### PR TITLE
Adding a gsub to fix C# anchor issue

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -166,7 +166,7 @@ class App < Cuba
   end
 
   def anchorize(str)
-    str.downcase.gsub(/[\s+]/, '-').gsub(/[^[:alnum:]-]/, "")
+    str.downcase.gsub(/#/, "-sharp").gsub(/[\s+]/, '-').gsub(/[^[:alnum:]-]/, "")
   end
 
   def topic(template)


### PR DESCRIPTION
Fixes #182

Added a gsub to the anchorize(str) function to swap out `#` in language names with a `-sharp`. It doesn't change the heading or any visible text, just the anchor URL; see attached screenshot.

![c-sharp](https://user-images.githubusercontent.com/5281651/66858507-a9fa1980-ef46-11e9-9ecf-380aa9bd51f0.png)
