### PR TITLE
Denies `RESTORE` in interactive console

### DIFF
--- a/lib/interactive/commands.rb
+++ b/lib/interactive/commands.rb
@@ -23,7 +23,6 @@ module Interactive
     "pttl" => [:first],
     "rename" => [:all],
     "renamenx" => [:all],
-    "restore" => [:first],
     "scan" => [:custom],
     "sort" => [:custom],
     "touch" => [:all],

--- a/scripts/generate_interactive_commands.rb
+++ b/scripts/generate_interactive_commands.rb
@@ -46,6 +46,7 @@ DENY_COMMANDS = %w(
   migrate
   xread
   xreadgroup
+  restore
 ).freeze
 
 def allowed_commands


### PR DESCRIPTION
Reduces the chance for abuse