### PR TITLE
Improve security of download links using HTTPS

### DIFF
--- a/views/download.haml
+++ b/views/download.haml
@@ -35,7 +35,7 @@
                 Release notes
 
             - if channel == :stable
-              - download_link = "http://download.redis.io/releases/redis-#{download[:version]}.tar.gz"
+              - download_link = "https://download.redis.io/releases/redis-#{download[:version]}.tar.gz"
             - elsif channel == :docker
               - download_link = download[:url]
             - else
@@ -71,7 +71,7 @@
 
         or
 
-        - download_link = "http://download.redis.io/releases/redis-#{download[:version]}.tar.gz"
+        - download_link = "https://download.redis.io/releases/redis-#{download[:version]}.tar.gz"
 
         %a(href="#{download_link}")
           download #{download[:version]}.
@@ -89,13 +89,13 @@
       %strong Scripts and other automatic downloads
       can easily access the tarball of the latest Redis stable version at
       = succeed "," do
-        %a{:href => "http://download.redis.io/redis-stable.tar.gz"} http://download.redis.io/redis-stable.tar.gz
+        %a{:href => "https://download.redis.io/redis-stable.tar.gz"} https://download.redis.io/redis-stable.tar.gz
       and its respective SHA256 sum at
       = succeed "." do
-        %a{:href => "http://download.redis.io/redis-stable.tar.gz.SHA256SUM"} http://download.redis.io/redis-stable.tar.gz.SHA256SUM
+        %a{:href => "https://download.redis.io/redis-stable.tar.gz.SHA256SUM"} https://download.redis.io/redis-stable.tar.gz.SHA256SUM
       The source code of the latest stable release is
       = succeed "," do
-        %a{:href => "http://download.redis.io/redis-stable"} always browsable here
+        %a{:href => "https://download.redis.io/redis-stable"} always browsable here
       use the file
       %strong src/version.h
       in order to extract the version in an automatic way.
@@ -113,7 +113,7 @@
     %pre
       %code
         :preserve
-          $ wget http://download.redis.io/releases/redis-#{STABLE_VERSION}.tar.gz
+          $ wget https://download.redis.io/releases/redis-#{STABLE_VERSION}.tar.gz
           $ tar xzf redis-#{STABLE_VERSION}.tar.gz
           $ cd redis-#{STABLE_VERSION}
           $ make

--- a/views/home.haml
+++ b/views/home.haml
@@ -20,7 +20,7 @@
       %h2 Download it
 
       %p
-        %a(href="http://download.redis.io/releases/redis-#{STABLE_VERSION}.tar.gz") Redis #{STABLE_VERSION} is the latest stable version.
+        %a(href="https://download.redis.io/releases/redis-#{STABLE_VERSION}.tar.gz") Redis #{STABLE_VERSION} is the latest stable version.
         Interested in release candidates or unstable versions?
         %a(href="/download") Check the downloads page.
 


### PR DESCRIPTION
This PR will, if merged, improve the security of downloads by switching from insecure HTTP to secure HTTPS.

The docs currently advise people to `wget http://download.redis.io/releases/redis-blah.tar.gz` which means it is trivial for an attacker to MITM that request. Whilst there is a GitHub repo of tarball hashes which people can use to verify the integrity of what they've just downloaded, I think that switching the hyperlinks to HTTPS still provides a much-needed improvement. It also has some additional (albeit slightly limited) privacy benefits.