### PR TITLE
Disable Autocomplete for Command Search field

### DIFF
--- a/views/commands.haml
+++ b/views/commands.haml
@@ -14,7 +14,7 @@
 
       %label
         %span search for:
-        %input.js-command-reference-search(placeholder="e.g. #{@commands.sample.name}" autofocus)
+        %input.js-command-reference-search(placeholder="e.g. #{@commands.sample.name}" autofocus autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false")
 
   .container
     %ul


### PR DESCRIPTION
Safari for Mac enables autocomplete / autocorrect etc. by default. This is less than ideal for quick searches on the commands page, e.g. "SREM" is replaced with "seem" once I click away from the input.

This PR adds attributes to disable that behaviour.