### PR TITLE
Historical downloads are at https://download.redis.io/releases/

### DIFF
--- a/views/download.haml
+++ b/views/download.haml
@@ -78,7 +78,7 @@
 
     Historical downloads are still available on
     = succeed "." do
-      %a(href="https://download.redis.io/") https://download.redis.io/
+      %a(href="https://download.redis.io/releases/") https://download.redis.io/releases/
 
     %p
       %strong Scripts and other automatic downloads


### PR DESCRIPTION
Previously historical downloads linked to https://download.redis.io/ which linked to the latest stable and not any other release (ie did not link to the historical ones). In fact https://download.redis.io/ should have it's small amount of info added to https://redis.io/download which already includes a link to the latest stable and deleting https://download.redis.io/ to avoid redundancy but I don't know where that source is.