### PR TITLE
Removes Freenode IRC channel.

### DIFF
--- a/test/sitemap.rb
+++ b/test/sitemap.rb
@@ -24,7 +24,6 @@ scope do
     find(".desktop-header").click_link_or_button "Community"
 
     assert has_css?("a[href='http://groups.google.com/group/redis-db']", text: "mailing list")
-    assert has_content?("#redis")
     assert has_css?("a[href='http://twitter.com/redisfeed']", text: "Redis news feed")
 
     find(".desktop-header").click_link_or_button "Documentation"

--- a/views/community.md
+++ b/views/community.md
@@ -9,11 +9,10 @@ For bug reports please just use [Github](https://github.com/redis/redis).
 
 Other places where you can find people interested in Redis:
 
-* The [Redis Discord server](https://discord.gg/redis).
+* Meet people interested in Redis at the [Redis Discord server](https://discord.gg/redis).
 * The [Redis tag on Stack Overflow](http://stackoverflow.com/questions/tagged/redis?sort=newest&pageSize=30).
 * Follow [Redis news feed](http://twitter.com/redisfeed) on Twitter.
 * The Redis community uses a Reddit sub for news and certain announcements (that also always go to the ML): [/r/redis sub on Reddit](https://www.reddit.com/r/redis/).
-* Meet people interested in Redis in the `#redis` channel on Freenode ([web access link](http://webchat.freenode.net/?channels=redis)).
 
 Project governance
 ---


### PR DESCRIPTION
Due to the Freenode takeover. Currently the Discord server serves a
similar purpose, and we can consider opening additional channels on other
platforms.

Closes #239 