### PR TITLE
Included link for on-cpu profiling and tracing of Redis within Performance topic

### DIFF
--- a/views/documentation.md
+++ b/views/documentation.md
@@ -57,9 +57,13 @@ Redis' durability.
 * [Signals Handling](/topics/signals): How Redis handles signals.
 * [Connections Handling](/topics/clients): How Redis handles clients connections.
 * [High Availability](/topics/sentinel): Redis Sentinel is the official high availability solution for Redis.
+* [Redis Releases](/topics/releases): Redis development cycle and version numbering.
+
+Performance
+---
 * [Latency monitoring](/topics/latency-monitor): Redis integrated latency monitoring and reporting capabilities are helpful to tune Redis instances for low latency workloads.
 * [Benchmarks](/topics/benchmarks): See how fast Redis is in different platforms.
-* [Redis Releases](/topics/releases): Redis development cycle and version numbering.
+* [Redis on-CPU profiling and tracing](/topics/performance-on-cpu): See how to perform on-CPU resource bottlenecks analysis in Redis.
 
 Embedded and IoT
 ---


### PR DESCRIPTION
This PR requires https://github.com/redis/redis-doc/pull/1528 to merged priorly and moves the 3 topics related to performance to a performance subsection within the `documentation` page

new look:
![image](https://user-images.githubusercontent.com/5832149/123964699-a113da80-d9ab-11eb-9af1-768b6ccd5467.png)
