### PR TITLE
Adds 'bitmap' group to allowed interactive commands

### DIFF
--- a/scripts/generate_interactive_commands.rb
+++ b/scripts/generate_interactive_commands.rb
@@ -21,6 +21,7 @@ ALLOW_GROUPS = %w(
   scripting
   geo
   stream
+  bitmap
 ).freeze
 
 # Override ALLOW_GROUPS for some commands.

--- a/test/command_reference.rb
+++ b/test/command_reference.rb
@@ -29,7 +29,7 @@ scope do
   test "Command page with complex arguments" do
     visit "/commands"
 
-    click_link_or_button "SORT"
+    click_link(href: /\/sort$/)
 
     within "h1" do
       assert has_content?("[BY pattern]")


### PR DESCRIPTION
Should obsolete https://github.com/redis/redis-doc/pull/1631 and https://github.com/redis/redis-doc/pull/1632.

Also fixes an unrelated borked test.

Ref: redis/redis-doc#1621 introduced an ambigious locator