### PR TITLE
Update APT install instructions.

### DIFF
--- a/views/download.haml
+++ b/views/download.haml
@@ -138,8 +138,8 @@
     %pre
       %code
         :preserve
-          $ curl https://packages.redis.io/gpg | sudo apt-key add -
-          $ echo "deb https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+          $ curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+          $ echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
           $ sudo apt-get update
           $ sudo apt-get install redis
     %h3 From the official Ubuntu PPA


### PR DESCRIPTION
Avoid apt-key that is being deprecated, use more secure signed-by
settings.