### PR TITLE
New commands json

### DIFF
--- a/lib/reference.rb
+++ b/lib/reference.rb
@@ -56,6 +56,9 @@ class Reference
         end
 
         token = argument["token"]
+        if token == ""
+          token = "\"\""
+        end
         if multiple_token?
           res = "#{res} [#{token} #{res} ...]"
         elsif multiple?

--- a/lib/reference.rb
+++ b/lib/reference.rb
@@ -15,7 +15,9 @@ class Reference
     "cluster" => "Cluster",
     "geo" => "Geo",
     "stream" => "Streams",
-    "bitmap" => "Bitmaps"
+    "bitmap" => "Bitmaps",
+    "cluster" => "Cluster",
+    "sentinel" => "Sentinel"
   }
 
   class Command
@@ -27,7 +29,7 @@ class Reference
       end
 
       def type
-        [argument["type"]].flatten
+        argument["type"]
       end
 
       def optional?
@@ -38,55 +40,48 @@ class Reference
         argument["multiple"] || false
       end
 
+      def multiple_token?
+        argument["multiple_token"] || false
+      end
+
       def to_s
-        if argument["block"]
+        if type == "block"
           res = block(argument)
-        elsif argument["multiple"]
-          res = multiple(argument)
-        elsif argument["variadic"]
-          res = variadic(argument)
-        elsif argument["enum"]
-          res = enum(argument)
+        elsif type == "oneof"
+          res = oneof(argument)
+        elsif type != "pure-token"
+          res = argument["name"]
         else
-          res = simple(argument)
+          res = ""
         end
 
-        argument["optional"] ? "[#{res}]" : res
+        token = argument["token"]
+        if multiple_token?
+          res = "#{res} [#{token} #{res} ...]"
+        elsif multiple?
+          res = "#{res} [#{res} ...]"
+        end
+
+        if token
+          res = "#{token} #{res}"
+          res = res.strip! || res
+        end
+
+        optional? ? "[#{res}]" : res
       end
 
     private
 
       def block(argument)
-       argument["block"].map do |entry|
-        Argument.new(entry)
-       end.join(" ")
-      end
-
-      def multiple(argument)
-        complex(argument) do |part|
-          part.unshift(argument["command"]) if argument["command"]
-        end
-      end
-
-      def variadic(argument)
-        [argument["command"], complex(argument)].join(" ")
-      end
-
-      def complex(argument)
-        2.times.map do |i|
-          part = Array(argument["name"])
-          yield(part) if block_given?
-          part = part.join(" ")
-          i == 0 ? part : "[" + part + " ...]"
+        argument["arguments"].map do |entry|
+          Argument.new(entry)
         end.join(" ")
       end
 
-      def simple(argument)
-        [argument["command"], argument["name"]].compact.flatten.join(" ")
-      end
-
-      def enum(argument)
-        [argument["command"], argument["enum"].join("|")].compact.join(" ")
+      def oneof(argument)
+        argument["arguments"].map do |entry|
+          Argument.new(entry)
+        end.join("|")
       end
     end
 

--- a/test/command_reference.rb
+++ b/test/command_reference.rb
@@ -43,10 +43,10 @@ scope do
   test "Commands with spaces" do
     visit "/commands"
 
-    click_link_or_button "DEBUG OBJECT"
+    click_link_or_button "OBJECT ENCODING"
 
-    assert has_title?("DEBUG OBJECT")
-    assert has_css?("h1", text: "DEBUG OBJECT")
+    assert has_title?("OBJECT ENCODING")
+    assert has_css?("h1", text: "OBJECT ENCODING")
   end
 
   test "Missing command" do

--- a/test/formatting.rb
+++ b/test/formatting.rb
@@ -8,9 +8,9 @@ setup do
   reference
 end
 
-test "DEBUG OBJECT" do |reference|
-  res = "DEBUG OBJECT key"
-  assert_equal reference["DEBUG OBJECT"].to_s, res
+test "OBJECT ENCODING" do |reference|
+  res = "OBJECT ENCODING key"
+  assert_equal reference["OBJECT ENCODING"].to_s, res
 end
 
 test "DEL" do |reference|


### PR DESCRIPTION
This updates the website syntax render to new syntax of command arguments (see https://github.com/redis/redis/pull/9656)

Goes hand in hand with https://github.com/redis/redis-doc/pull/1714

The test fails and will continue to do so until the new "commands.json" is merged into redis-doc.