### PR TITLE
Render deprecation and history from command meta data

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -66,7 +66,7 @@ private
 
   def related_commands_for(group)
     commands.select do |command|
-      command.group == group
+      command.group == group && command.is_listed?
     end.sort_by(&:name)
   end
 

--- a/lib/reference.rb
+++ b/lib/reference.rb
@@ -113,6 +113,18 @@ class Reference
       command["complexity"]
     end
 
+    def deprecated_since
+      command["deprecated_since"]
+    end
+
+    def replaced_by
+      command["replaced_by"]
+    end
+
+    def history
+      command["history"]
+    end
+
     def to_param
       name.downcase.gsub(" ", "-")
     end

--- a/lib/reference.rb
+++ b/lib/reference.rb
@@ -125,6 +125,18 @@ class Reference
       command["history"]
     end
 
+    def is_helpsubcommand?
+      name.downcase.end_with?(" help")
+    end
+
+    def is_purecontainer?
+      command["arity"] == -2 && !command["arguments"]
+    end
+
+    def is_listed?
+      !is_purecontainer? && !is_helpsubcommand?
+    end
+
     def to_param
       name.downcase.gsub(" ", "-")
     end

--- a/public/styles.css
+++ b/public/styles.css
@@ -172,6 +172,7 @@ body { background-color: white; color: #333333; padding: 0; margin: 0; }
 .text sup { line-height: 100%; vertical-align: super; font-size: 70%; }
 .text pre code, .text .example { display: inline-block; padding: 15px; border: 1px solid #eeeeee; margin: 10px 0; background-color: #fefefe; }
 .text .metadata { border-left: 3px solid #dfdfdf; color: #666666; font-size: 0.9em; margin: 0 0 1.5em 0; padding: 5px 15px; background: #fcfcfc; }
+.text .deprecation { border-left: 3px solid #d42e15; color: #333333; font-size: 0.9em; margin: 0 0 1.5em 0; padding: 5px 15px; background: #fcfcfc; }
 .text .example { max-height: 400px; max-width: 390px; overflow: auto; }
 .text .example .monospace, .text .example pre, .text .example input { margin: 0; padding: 0; line-height: 20px; font-size: 12px; font-family: Menlo, monospace; }
 .text .example pre { clear: both; }

--- a/views/commands.haml
+++ b/views/commands.haml
@@ -19,13 +19,14 @@
   .container
     %ul
       - @commands.each do |command|
-        %li(data-group="#{command.command["group"]}" data-name="#{command.name.downcase}")
-          %a(href="/commands/#{command.to_param}")
-            %span.command
-              = command.name
+        - if command.is_listed?
+          %li(data-group="#{command.command["group"]}" data-name="#{command.name.downcase}")
+            %a(href="/commands/#{command.to_param}")
+              %span.command
+                = command.name
 
-              %span.args
-                - command.arguments.each do |argument|
-                  = argument
+                %span.args
+                  - command.arguments.each do |argument|
+                    = argument
 
-            %span.summary= command.command["summary"]
+              %span.summary= command.command["summary"]

--- a/views/commands/name.haml
+++ b/views/commands/name.haml
@@ -21,7 +21,23 @@
           - if @command.complexity
             %p <strong>Time complexity:</strong> #{@command.complexity}
 
+        - if @command.deprecated_since
+          %div.deprecation
+            %p
+              <strong>Deprecation notice:</strong>
+              as of Redis version #{@command.deprecated_since} this command is
+              considered as deprecated. While it is unlikely that it will be
+              completely removed, prefer using #{@command.replaced_by} in its
+              stead.
+
         ~ custom_view("#{documentation_path}/commands/#{@name.downcase}.md", {}, layout: false)
+
+        - if @command.history
+          %h2 History
+          %ul
+            - @command.history.each do |entry|
+              %li
+                Redis version >= #{entry[0]}: #{entry[1]}
 
       .article-aside
         %aside


### PR DESCRIPTION
Pending https://github.com/redis/redis-doc/pull/1722

This renders a deprecation notice (when applicable) and history per command from commands.json
This filters out the `.* HELP` and pure container commands from the list and related sidebar.

Deprecation notice:
![image](https://user-images.githubusercontent.com/6059516/147692205-f82fe4fe-5351-4362-973d-67e9dfac1f83.png)

History:
![image](https://user-images.githubusercontent.com/6059516/147692255-c1689f4e-7c72-4adb-9599-00b6088a1474.png)

No "HELP" and pure containers (look for `ACL` and `ACL HELP`) in the list and related:
![image](https://user-images.githubusercontent.com/6059516/147692343-ce98aff2-9b29-41a5-801c-365f63d86f6e.png)
![image](https://user-images.githubusercontent.com/6059516/147692374-02a5f1bc-1f63-49ec-8eb0-191e4fc9512f.png)
